### PR TITLE
[PAGOPA-930] Retrieve stations by broker

### DIFF
--- a/src/main/java/it/gov/pagopa/apiconfig/starter/repository/StazioniRepository.java
+++ b/src/main/java/it/gov/pagopa/apiconfig/starter/repository/StazioniRepository.java
@@ -40,9 +40,20 @@ public interface StazioniRepository extends JpaRepository<Stazioni, Long> {
       @Param("idStazione") String idStazione,
       Pageable pageable);
 
-  @Query(value = "select distinct s from Stazioni s where (:fkIntermediario = :fkIntermediario)")
-  Page<Stazioni> findAllByFilter(
+  @Query(value = "select distinct s from Stazioni s where (:fkIntermediario = :fkIntermediario) order by s.idStazione")
+  Page<Stazioni> findAllByFiltersOrderById(
       @Param("fkIntermediario") Long fkIntermediario,
+      Pageable pageable
+  );
+
+  @Query(
+      value =
+          "select distinct s from Stazioni s where (:fkIntermediario is null or s.fkIntermediarioPa"
+              + " = :fkIntermediario) and (:idStazione is null or upper(s.idStazione) like"
+              + " concat('%', upper(:idStazione), '%')) order by s.idStazione")
+  Page<Stazioni> findAllByFiltersOrderById(
+      @Param("fkIntermediario") Long fkIntermediario,
+      @Param("idStazione") String idStazione,
       Pageable pageable
   );
 }

--- a/src/main/java/it/gov/pagopa/apiconfig/starter/repository/StazioniRepository.java
+++ b/src/main/java/it/gov/pagopa/apiconfig/starter/repository/StazioniRepository.java
@@ -39,4 +39,10 @@ public interface StazioniRepository extends JpaRepository<Stazioni, Long> {
       @Param("fkIntermediario") Long fkIntermediario,
       @Param("idStazione") String idStazione,
       Pageable pageable);
+
+  @Query(value = "select distinct s from Stazioni s where (:fkIntermediario = :fkIntermediario)")
+  Page<Stazioni> findAllByFilter(
+      @Param("fkIntermediario") Long fkIntermediario,
+      Pageable pageable
+  );
 }


### PR DESCRIPTION
With this PR, there will be added two new methods on repository in order to permits a query operation filtering by broker identifier and station identifier.  

#### List of Changes
 - Added new method for retrieve paginated stations filtering by broker identifier
 - Added new method for retrieve paginated stations filtering by broker identifier and station identifier

#### Motivation and Context
This new methods are required in order to add new functionalities to `pagopa-apiconfig-selfcare-integration` project.

#### How Has This Been Tested?
Tested in local environment

#### Screenshots (if appropriate):

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
