### PR TITLE
fix: resolved typo on queries

### DIFF
--- a/src/main/java/it/gov/pagopa/apiconfig/starter/repository/StazioniRepository.java
+++ b/src/main/java/it/gov/pagopa/apiconfig/starter/repository/StazioniRepository.java
@@ -40,11 +40,12 @@ public interface StazioniRepository extends JpaRepository<Stazioni, Long> {
       @Param("idStazione") String idStazione,
       Pageable pageable);
 
-  @Query(value = "select distinct s from Stazioni s where (s.fkIntermediarioPa = :fkIntermediario) order by s.idStazione")
+  @Query(
+      value =
+          "select distinct s from Stazioni s where (s.fkIntermediarioPa = :fkIntermediario) order"
+              + " by s.idStazione")
   Page<Stazioni> findAllByFiltersOrderById(
-      @Param("fkIntermediario") Long fkIntermediario,
-      Pageable pageable
-  );
+      @Param("fkIntermediario") Long fkIntermediario, Pageable pageable);
 
   @Query(
       value =
@@ -54,6 +55,5 @@ public interface StazioniRepository extends JpaRepository<Stazioni, Long> {
   Page<Stazioni> findAllByFiltersOrderById(
       @Param("fkIntermediario") Long fkIntermediario,
       @Param("idStazione") String idStazione,
-      Pageable pageable
-  );
+      Pageable pageable);
 }

--- a/src/main/java/it/gov/pagopa/apiconfig/starter/repository/StazioniRepository.java
+++ b/src/main/java/it/gov/pagopa/apiconfig/starter/repository/StazioniRepository.java
@@ -40,7 +40,7 @@ public interface StazioniRepository extends JpaRepository<Stazioni, Long> {
       @Param("idStazione") String idStazione,
       Pageable pageable);
 
-  @Query(value = "select distinct s from Stazioni s where (:fkIntermediario = :fkIntermediario) order by s.idStazione")
+  @Query(value = "select distinct s from Stazioni s where (s.fkIntermediarioPa = :fkIntermediario) order by s.idStazione")
   Page<Stazioni> findAllByFiltersOrderById(
       @Param("fkIntermediario") Long fkIntermediario,
       Pageable pageable


### PR DESCRIPTION
With this commit, a typo on query for retrieve the list of station by broker is resolved. The bug was not found in a first test session because the used query was the one with station identifier set.

#### List of Changes
Resolved typo on query

#### Motivation and Context
This commit is required for resolve the bug on query described

#### How Has This Been Tested?
 - Tested in local environment

#### Screenshots (if appropriate):

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
