### PR TITLE
[PAGOPA-668] fix: set CanaliRepository usable with JPA Specification

### DIFF
--- a/src/main/java/it/gov/pagopa/apiconfig/starter/repository/CanaliRepository.java
+++ b/src/main/java/it/gov/pagopa/apiconfig/starter/repository/CanaliRepository.java
@@ -3,12 +3,14 @@ package it.gov.pagopa.apiconfig.starter.repository;
 import it.gov.pagopa.apiconfig.starter.entity.Canali;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 @SuppressWarnings(
     "java:S100") // Disabled naming convention rule for method name to use Spring Data interface
 @Repository
-public interface CanaliRepository extends JpaRepository<Canali, Long> {
+public interface CanaliRepository extends JpaRepository<Canali, Long>,
+    JpaSpecificationExecutor<Canali> {
 
   Optional<Canali> findByIdCanale(String idCanale);
 }


### PR DESCRIPTION
This PR contains an update made on existing repository in order to permits the use of JPA Specifications on APIConfig core module.

#### List of Changes
 - Updated `ChannelRepository`, extending JPA Specification's executor interface

#### Motivation and Context
These changes are required in order to permits the use of JPA Specification-generated query

#### How Has This Been Tested?
 - Tested in local environment

#### Screenshots (if appropriate):

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.