### PR TITLE
[PAGOPA-1076] Deleting unused NEW_PASSWORD field 

### DIFF
--- a/src/main/java/it/gov/pagopa/apiconfig/starter/entity/Canali.java
+++ b/src/main/java/it/gov/pagopa/apiconfig/starter/entity/Canali.java
@@ -56,11 +56,6 @@ public class Canali implements Serializable {
   private String ip;
 
   @ToString.Exclude
-  @Column(name = "NEW_PASSWORD", length = 15)
-  @EqualsAndHashCode.Exclude
-  private String newPassword;
-
-  @ToString.Exclude
   @Column(name = "PASSWORD", length = 15)
   private String password;
 

--- a/src/main/java/it/gov/pagopa/apiconfig/starter/entity/Stazioni.java
+++ b/src/main/java/it/gov/pagopa/apiconfig/starter/entity/Stazioni.java
@@ -49,10 +49,6 @@ public class Stazioni {
   private String ip;
 
   @ToString.Exclude
-  @Column(name = "NEW_PASSWORD")
-  private String newPassword;
-
-  @ToString.Exclude
   @Column(name = "PASSWORD")
   private String password;
 


### PR DESCRIPTION
This PR contains a fix made on Canali and Stazioni JPA entities in order to remove the NEW_PASSWORD column.

#### List of Changes
 - Removed columns related to new password information

#### Motivation and Context
This change is required in order to permits to delete all references to these column on JPA entity.

#### How Has This Been Tested?
 - Tested in local environment

#### Screenshots (if appropriate):

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
