### PR TITLE
fix: added orphan-removal clause on IbanMaster's attribute relation

### DIFF
--- a/src/main/java/it/gov/pagopa/apiconfig/starter/entity/IbanMaster.java
+++ b/src/main/java/it/gov/pagopa/apiconfig/starter/entity/IbanMaster.java
@@ -66,7 +66,7 @@ public class IbanMaster {
   private Iban iban;
 
   @ToString.Exclude
-  @OneToMany(fetch = FetchType.LAZY, mappedBy = "fkIbanMaster", cascade = CascadeType.ALL)
+  @OneToMany(fetch = FetchType.LAZY, mappedBy = "fkIbanMaster", cascade = CascadeType.ALL, orphanRemoval = true)
   @EqualsAndHashCode.Exclude
   private List<IbanAttributeMaster> ibanAttributesMasters;
 }


### PR DESCRIPTION
When an IBAN is updated by APIConfig, the attributes related to it will always be removed and replaced by new ones. But, after several tests, a missing unique-key for the tuple (FK_IBAN_MASTER, FK_IBAN_ATTRIBUTE) in DB caused a wrong insertion of the same record too many times.
This PR contains a fix made on IbanMaster entity in order to add the remove action on orphans when an update on IBAN is made.

#### List of Changes
 - Addded `orphanRemoval` clause on IbanMaster relation

#### Motivation and Context
This fix permits to resolve a bug that caused the orphan relation to not be removed

#### How Has This Been Tested?
 - Tested in local environment
 - Tested in DEV environment

#### Screenshots (if appropriate):

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
