### PR TITLE
feat: added field CBill in PA table entity

### DIFF
--- a/src/main/java/it/gov/pagopa/apiconfig/starter/entity/Pa.java
+++ b/src/main/java/it/gov/pagopa/apiconfig/starter/entity/Pa.java
@@ -84,6 +84,9 @@ public class Pa {
   @Column(name = "DESCRIZIONE")
   private String description;
 
+  @Column(name = "CBILL")
+  private String cbill;
+
   @ToString.Exclude
   @OneToMany(fetch = FetchType.LAZY, mappedBy = "fkPa")
   @EqualsAndHashCode.Exclude


### PR DESCRIPTION
With this PR a new field named `cbill` is added in `Pa` JPA entity. This new field permits to add the information about the CBill code to be set on creditor institutions.  
In order to be retro-compatible, this field is set as nullable.

#### List of Changes
 - Add new field for map `CBILL` column in `PA` table

#### Motivation and Context
This update permits to add this new field

#### How Has This Been Tested?
 - Tested in local environment

#### Screenshots (if appropriate):

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
